### PR TITLE
start / stop session

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@
     WORKDIR /workspace
     COPY pom.xml ./
     COPY src ./src
-    RUN mvn clean package -DskipTests
+    RUN mvn clean package 
 
 
     FROM openjdk:21-jdk-slim

--- a/backend/src/main/java/tqs/evsync/backend/controller/ChargingSessionController.java
+++ b/backend/src/main/java/tqs/evsync/backend/controller/ChargingSessionController.java
@@ -1,0 +1,38 @@
+package tqs.evsync.backend.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tqs.evsync.backend.model.ChargingSession;
+import tqs.evsync.backend.service.ChargingSessionService;
+
+@RestController
+@RequestMapping("/api/sessions")
+public class ChargingSessionController {
+
+    private final ChargingSessionService svc;
+
+    public ChargingSessionController(ChargingSessionService svc) {
+        this.svc = svc;
+    }
+
+    @PostMapping("/start/{reservationId}")
+    public ResponseEntity<ChargingSession> start(
+            @PathVariable Long reservationId) {
+        ChargingSession session = svc.startSession(reservationId);
+        return ResponseEntity.ok(session);
+    }
+
+    @PostMapping("/stop/{sessionId}")
+    public ResponseEntity<ChargingSession> stop(
+            @PathVariable Long sessionId) {
+        ChargingSession session = svc.stopSession(sessionId);
+        return ResponseEntity.ok(session);
+    }
+
+    @GetMapping("/{sessionId}")
+    public ResponseEntity<ChargingSession> getSession(
+            @PathVariable Long sessionId) {
+        ChargingSession session = svc.getSessionById(sessionId);
+        return ResponseEntity.ok(session);
+    }
+}

--- a/backend/src/main/java/tqs/evsync/backend/model/ChargingOutlet.java
+++ b/backend/src/main/java/tqs/evsync/backend/model/ChargingOutlet.java
@@ -2,11 +2,14 @@ package tqs.evsync.backend.model;
 
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import tqs.evsync.backend.model.enums.OutletStatus;
+import jakarta.persistence.EnumType;
 
 @Entity
 public class ChargingOutlet {
@@ -16,6 +19,9 @@ public class ChargingOutlet {
 
     private double costPerHour;
     private int maxPower;
+
+	@Enumerated(EnumType.STRING)
+	private OutletStatus status;
 
 
     @ManyToOne
@@ -51,4 +57,12 @@ public class ChargingOutlet {
     public void setChargingStation(ChargingStation chargingStation) {
         this.chargingStation = chargingStation;
     }
+
+
+	public OutletStatus getStatus() {
+		return status;
+	}
+	public void setStatus(OutletStatus status) {
+		this.status = status;
+	}
 }

--- a/backend/src/main/java/tqs/evsync/backend/model/ChargingSession.java
+++ b/backend/src/main/java/tqs/evsync/backend/model/ChargingSession.java
@@ -97,4 +97,12 @@ public class ChargingSession {
     public void setOutlet(ChargingOutlet outlet) {
         this.outlet = outlet;
     }
+
+    public ChargingSessionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ChargingSessionStatus status) {
+        this.status = status;
+    }
 }

--- a/backend/src/main/java/tqs/evsync/backend/model/enums/OutletStatus.java
+++ b/backend/src/main/java/tqs/evsync/backend/model/enums/OutletStatus.java
@@ -1,0 +1,8 @@
+package tqs.evsync.backend.model.enums;
+
+public enum OutletStatus {
+    AVAILABLE,
+    OCCUPIED,
+    OUT_OF_SERVICE,
+    MAINTENANCE
+}

--- a/backend/src/main/java/tqs/evsync/backend/model/enums/ReservationStatus.java
+++ b/backend/src/main/java/tqs/evsync/backend/model/enums/ReservationStatus.java
@@ -4,5 +4,6 @@ public enum ReservationStatus {
 	PENDING,	// The reservation is pending confirmation, needs to be payed
 	CONFIRMED,	// The reservation is confirmed, the user has payed
 	CANCELLED,	// The reservation is cancelled, the user has not payed or has cancelled
-	COMPLETED	// The reservation is completed, the user has payed and the reservation is accepted
+	COMPLETED,	// The reservation is completed, the user has payed and the reservation is accepted
+	IN_PROGRESS
 }

--- a/backend/src/main/java/tqs/evsync/backend/repository/ChargingSessionRepository.java
+++ b/backend/src/main/java/tqs/evsync/backend/repository/ChargingSessionRepository.java
@@ -1,0 +1,8 @@
+package tqs.evsync.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import tqs.evsync.backend.model.ChargingSession;
+
+public interface ChargingSessionRepository 
+        extends JpaRepository<ChargingSession,Long> {
+}

--- a/backend/src/main/java/tqs/evsync/backend/service/ChargingSessionService.java
+++ b/backend/src/main/java/tqs/evsync/backend/service/ChargingSessionService.java
@@ -1,0 +1,93 @@
+package tqs.evsync.backend.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+import tqs.evsync.backend.model.*;
+import tqs.evsync.backend.model.enums.ReservationStatus;
+import tqs.evsync.backend.model.enums.OutletStatus;
+
+import tqs.evsync.backend.model.enums.ChargingSessionStatus;
+import tqs.evsync.backend.repository.*;
+
+@Service
+public class ChargingSessionService {
+
+    private final ChargingSessionRepository sessionRepo;
+    private final ReservationRepository    reservationRepo;
+    private final ChargingOutletRepository outletRepo;
+
+    public ChargingSessionService(ChargingSessionRepository s,
+                                  ReservationRepository    r,
+                                  ChargingOutletRepository o) {
+        this.sessionRepo     = s;
+        this.reservationRepo = r;
+        this.outletRepo      = o;
+    }
+
+    @Transactional
+    public ChargingSession startSession(Long reservationId) {
+        // 1) lookup reservation & outlet
+        Reservation res = reservationRepo.findById(reservationId)
+            .orElseThrow(() -> new IllegalArgumentException("Reservação não encontrada"));
+        ChargingOutlet outlet = res.getOutlet();
+        // 2) mark both reservation & outlet in use
+        if (res.getStatus() != ReservationStatus.CONFIRMED) {
+            throw new IllegalStateException("Reserva não confirmada");
+        }
+        res.setStatus(ReservationStatus.IN_PROGRESS);
+        outlet.setStatus(OutletStatus.OCCUPIED);     // <-- you’ll need an enum/field
+        reservationRepo.save(res);
+        outletRepo.save(outlet);
+
+        // 3) create session
+        ChargingSession session = new ChargingSession();
+        session.setReservation(res);
+        session.setOutlet(outlet);
+        session.setStatus(ChargingSessionStatus.ACTIVE);
+        session.setStartTime(LocalDateTime.now());
+        return sessionRepo.save(session);
+    }
+
+    @Transactional
+    public ChargingSession stopSession(Long sessionId) {
+        ChargingSession session = sessionRepo.findById(sessionId)
+            .orElseThrow(() -> new IllegalArgumentException("Sessão não encontrada"));
+
+        if (session.getStatus() != ChargingSessionStatus.ACTIVE) {
+            throw new IllegalStateException("Sessão não está ativa");
+        }
+
+        // 1) stamp end time
+        session.setEndTime(LocalDateTime.now());
+
+        // 2) compute based on the reservation’s booked duration
+        double hoursBooked     = session.getReservation().getDuration();         // e.g. 1.0
+        double costPerHour     = session.getOutlet().getCostPerHour();           // €/h
+        double maxPower        = session.getOutlet().getMaxPower();              // kW
+
+        // energy in kWh = power (kW) * hours
+        double energyConsumed  = hoursBooked * maxPower;
+        double totalCost       = hoursBooked * costPerHour;
+
+        session.setEnergyConsumed(energyConsumed);
+        session.setTotalCost(totalCost);
+        session.setStatus(ChargingSessionStatus.COMPLETED);
+
+        // 3) free up the outlet
+        ChargingOutlet outlet = session.getOutlet();
+        outlet.setStatus(OutletStatus.AVAILABLE);
+        outletRepo.save(outlet);
+
+        // 4) mark reservation completed
+        Reservation res = session.getReservation();
+        res.setStatus(ReservationStatus.COMPLETED);
+        reservationRepo.save(res);
+
+        return sessionRepo.save(session);
+    }
+    public ChargingSession getSessionById(Long sessionId) {
+        return sessionRepo.findById(sessionId)
+            .orElseThrow(() -> new IllegalArgumentException("Sessão não encontrada"));
+    }
+}

--- a/backend/src/test/java/tqs/evsync/backend/ChargingSessionTestIT.java
+++ b/backend/src/test/java/tqs/evsync/backend/ChargingSessionTestIT.java
@@ -1,0 +1,110 @@
+package tqs.evsync.backend;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import tqs.evsync.backend.model.*;
+import tqs.evsync.backend.model.enums.*;
+import tqs.evsync.backend.repository.*;
+import tqs.evsync.backend.model.ChargingSession;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import java.time.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ChargingSessionTestIT {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @Autowired
+    private ReservationRepository reservationRepo;
+    @Autowired
+    private ChargingSessionRepository sessionRepo;
+    @Autowired
+    private ChargingOutletRepository outletRepo;
+    @Autowired
+    private ChargingStationRepository stationRepo;
+    @Autowired
+    private ConsumerRepository consumerRepo;
+
+    private Reservation reservation;
+    private ChargingOutlet outlet;
+
+    @BeforeEach
+    void setUp() {
+        // 1) Create a station & outlet
+        ChargingStation station = new ChargingStation();
+        station.setLatitude(0.0);
+        station.setLongitude(0.0);
+        station.setStatus(ChargingStationStatus.AVAILABLE);
+        station = stationRepo.save(station);
+
+        outlet = new ChargingOutlet();
+        outlet.setStatus(OutletStatus.AVAILABLE);
+        outlet.setCostPerHour(2.0);
+        outlet.setMaxPower(50);
+        outletRepo.save(outlet);
+
+        // 2) Create a consumer & a reservation
+        Consumer consumer = new Consumer();
+        consumer.setWallet(1000);
+        consumer = consumerRepo.save(consumer);
+
+        reservation = new Reservation();
+        reservation.setConsumer(consumer);
+        reservation.setStation(station);
+        reservation.setOutlet(outlet);
+        reservation.setStartTime(LocalDateTime.now().toString());
+        reservation.setDuration(1.0);
+        reservation.setStatus(ReservationStatus.CONFIRMED);
+        reservation = reservationRepo.save(reservation);
+    }
+
+    @AfterEach
+    void tearDown() {
+        sessionRepo.deleteAll();
+        reservationRepo.deleteAll();
+        outletRepo.deleteAll();
+        stationRepo.deleteAll();
+        consumerRepo.deleteAll();
+    }
+
+    @Test
+    void whenStartAndStopSession_thenReturnsCompletedSession() {
+        // Start
+        ResponseEntity<ChargingSession> startResp =
+            rest.postForEntity(url("/api/sessions/start/" + reservation.getId()),
+                               null,
+                               ChargingSession.class);
+
+        assertThat(startResp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        ChargingSession started = startResp.getBody();
+        assertThat(started).isNotNull();
+        assertThat(started.getStatus()).isEqualTo(ChargingSessionStatus.ACTIVE);
+        assertThat(started.getStartTime()).isNotNull();
+
+        // Stop
+        ResponseEntity<ChargingSession> stopResp =
+            rest.postForEntity(url("/api/sessions/stop/" + started.getId()),
+                               null,
+                               ChargingSession.class);
+
+        assertThat(stopResp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        ChargingSession stopped = stopResp.getBody();
+        assertThat(stopped.getStatus()).isEqualTo(ChargingSessionStatus.COMPLETED);
+        assertThat(stopped.getEndTime()).isNotNull();
+        assertThat(stopped.getTotalCost()).isGreaterThan(0.0);
+    }
+
+    private String url(String path) {
+        return "http://localhost:" + port + path;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to manage charging sessions in the backend, including starting, stopping, and retrieving session details. It also enhances the data model with new fields and enums and includes integration tests to verify the functionality. Below are the most significant changes grouped by theme:

### Charging Session Management

* Added `ChargingSessionController` to handle API endpoints for starting, stopping, and retrieving charging sessions (`/api/sessions`) (`[backend/src/main/java/tqs/evsync/backend/controller/ChargingSessionController.javaR1-R38](diffhunk://#diff-e838e7115a338885091ea0df3fb8d8b6e54acf4e28cb4b1cd62d9ccf0de5fa91R1-R38)`).
* Implemented `ChargingSessionService` to manage the business logic for starting and stopping charging sessions, including updating reservation and outlet statuses and calculating costs (`[backend/src/main/java/tqs/evsync/backend/service/ChargingSessionService.javaR1-R93](diffhunk://#diff-19b8f44cbf7053205323e9a0944f24492e43798d3122e32339a5e79d901a0729R1-R93)`).
* Created `ChargingSessionRepository` to interact with the database for `ChargingSession` entities (`[backend/src/main/java/tqs/evsync/backend/repository/ChargingSessionRepository.javaR1-R8](diffhunk://#diff-23d5d26d2025cc694e5a330a4aa27d1a9739538c6aa3efb9167db8a20afd97cfR1-R8)`).

### Data Model Enhancements

* Added `OutletStatus` enum to represent the state of a charging outlet (e.g., AVAILABLE, OCCUPIED) and integrated it into the `ChargingOutlet` entity with getter and setter methods (`[[1]](diffhunk://#diff-4affd53f58ce5d89ac7d2edc530fbda9be4dc379d47f92759e9f92cdd3f7373fR1-R8)`, `[[2]](diffhunk://#diff-2ec5949c1f33f23b5fa16917ded86dbce8f6b05b25a1cc9af058010afe915e28R5-R12)`, `[[3]](diffhunk://#diff-2ec5949c1f33f23b5fa16917ded86dbce8f6b05b25a1cc9af058010afe915e28R23-R25)`, `[[4]](diffhunk://#diff-2ec5949c1f33f23b5fa16917ded86dbce8f6b05b25a1cc9af058010afe915e28R60-R67)`).
* Updated `ReservationStatus` enum to include a new `IN_PROGRESS` status for reservations that are currently being used (`[backend/src/main/java/tqs/evsync/backend/model/enums/ReservationStatus.javaL7-R8](diffhunk://#diff-277d7c36afadd3f15fdd8e3ce14939505887676b2199248bdf3787a47f14e7f2L7-R8)`).

### Integration Testing

* Introduced `ChargingSessionTestIT`, an integration test class to verify the end-to-end functionality of starting and stopping charging sessions, including database interactions and API responses (`[backend/src/test/java/tqs/evsync/backend/ChargingSessionTestIT.javaR1-R110](diffhunk://#diff-a38607c9117cea41e170822d3877b27f31a3e843376d476e97e6f13e654656feR1-R110)`).

### Other Changes

* Modified the `Dockerfile` to ensure tests are run during the Maven build process by removing the `-DskipTests` flag (`[backend/DockerfileL6-R6](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486L6-R6)`).## Description




## Jira Context

Jira Issue: 



## How to test
