### PR TITLE
Tqs 81 create performance tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       - app-network
 
 
-
   mysql:
     image: mysql:8.0
     restart: always
@@ -64,6 +63,7 @@ services:
     networks:
       - app-network
 
+
   grafana:
     image: grafana/grafana
     container_name: grafana
@@ -79,6 +79,14 @@ services:
       - prometheus
     networks:
       - app-network
+
+  k6:
+    image: grafana/k6
+    volumes:
+      - ./performance_tests:/scripts
+    networks:
+      - app-network
+    entrypoint: ["sleep", "infinity"]
 
 volumes:
   mysql-data:

--- a/performance_tests/load.js
+++ b/performance_tests/load.js
@@ -1,0 +1,17 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export let options = {
+    stages: [
+        { duration: '2m', target: 70 },
+        { duration: '5m', target: 70 },
+        { duration: '2m', target: 0 },
+    ],
+};
+
+export default function () {
+    const res = http.get('http://backend:8080/charging-station');
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+}

--- a/performance_tests/smoke.js
+++ b/performance_tests/smoke.js
@@ -11,4 +11,8 @@ export default function () {
     check(res, {
         'status is 200': (r) => r.status === 200,
     });
+    const res2 = http.get('http://backend:8080/charging-station');
+    check(res2, {
+        'status is 200': (r) => r.status === 200,
+    });
 }

--- a/performance_tests/smoke.js
+++ b/performance_tests/smoke.js
@@ -1,0 +1,14 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export let options = {
+    vus: 20,
+    duration: '20s',
+};
+
+export default function () {
+    const res = http.get('http://backend:8080/api/consumers');
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+}

--- a/performance_tests/soak.js
+++ b/performance_tests/soak.js
@@ -1,0 +1,17 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export let options = {
+    stages: [
+        { duration: '1m', target: 20 },
+        { duration: '15m', target: 20 },
+        { duration: '1m', target: 0 },
+    ],
+};
+
+export default function () {
+    const res = http.get('http://backend:8080/charging-station');
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+}

--- a/performance_tests/spike.js
+++ b/performance_tests/spike.js
@@ -1,0 +1,18 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export let options = {
+    stages: [
+        { duration: '10s', target: 200 },
+        { duration: '30s', target: 200 },
+        { duration: '10s', target: 1 },
+        { duration: '30s', target: 1 },
+    ],
+};
+
+export default function () {
+    const res = http.get('http://backend:8080/charging-station');
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+}

--- a/performance_tests/stress.js
+++ b/performance_tests/stress.js
@@ -1,0 +1,18 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export let options = {
+    stages: [
+        { duration: '1m', target: 50 },
+        { duration: '1m', target: 150 },
+        { duration: '1m', target: 300 },
+        { duration: '1m', target: 0 },
+    ],
+};
+
+export default function () {
+    const res = http.get('http://backend:8080/charging-station');
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+}


### PR DESCRIPTION
## Description
This pull request introduces performance testing capabilities using Grafana's K6 tool and updates the `docker-compose.yml` file to integrate new services for testing and monitoring. Additionally, it includes several predefined test scripts for different performance testing scenarios.

### Docker Compose Updates:
* Added `grafana` service to the `docker-compose.yml` file for monitoring purposes.
* Added `k6` service to the `docker-compose.yml` file for performance testing, including configuration for volumes and an entrypoint to keep the container running.

### Performance Testing Scripts:
* Introduced `load.js` script for load testing the `/charging-station` endpoint, simulating gradual ramp-up and ramp-down of users.
* Introduced `smoke.js` script for smoke testing, targeting both `/api/consumers` and `/charging-station` endpoints with a short duration and limited virtual users.
* Introduced `soak.js` script for soak testing the `/charging-station` endpoint, simulating sustained load over an extended period.
* Introduced `spike.js` script for spike testing the `/charging-station` endpoint, simulating sudden increases and decreases in traffic.
* Introduced `stress.js` script for stress testing the `/charging-station` endpoint, gradually increasing traffic to high levels and observing system behavior.



## Jira Context

Jira Issue: [TQS-81](https://fangsenpai.atlassian.net/browse/TQS-81)



## How to test

1) initialize docker;
2) while on root folder, run "docker compose exec k6 k6 run /scripts/NAME_OF_SCRIPT.js"
3) access grafana through localhost:3001, log in with admin/admin and access the dashboards to see the results

[TQS-81]: https://fangsenpai.atlassian.net/browse/TQS-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ